### PR TITLE
removed an update of user cart

### DIFF
--- a/client/store/cart.js
+++ b/client/store/cart.js
@@ -1,6 +1,5 @@
 import axios from 'axios';
 import history from '../history';
-import {userOrderUpdate} from './index'
 
 //Action Types
 
@@ -110,8 +109,6 @@ export const addToCartThunk = (item, cart) =>
       .then(res => {
         const updatedCart = Object.assign({}, cart)
         updatedCart.orderDetails = [...updatedCart.orderDetails, res.data]
-        
-        dispatch(userOrderUpdate(updatedCart))
       })
       .catch()
     }

--- a/client/store/user.js
+++ b/client/store/user.js
@@ -7,7 +7,6 @@ import {userLogsOutRemoveCartAction, userLogsInAddCartThunk, userLogsInCreateCar
  */
 const GET_USER = 'GET_USER'
 const REMOVE_USER = 'REMOVE_USER'
-const USER_ORDER_UPDATE = 'USER_ORDER_UPDATE'
 
 /**
  * INITIAL STATE
@@ -19,7 +18,6 @@ const defaultUser = {}
  */
 const getUser = user => ({type: GET_USER, user})
 const removeUser = () => ({type: REMOVE_USER})
-export const userOrderUpdate = cart => ({type: USER_ORDER_UPDATE, cart})
 
 /**
  * THUNK CREATORS
@@ -71,10 +69,6 @@ export default function (state = defaultUser, action) {
       return action.user
     case REMOVE_USER:
       return defaultUser
-    case USER_ORDER_UPDATE:
-      const newState = Object.assign({}, state)
-      newState.orders = action.cart
-      return newState
     default:
       return state
   }


### PR DESCRIPTION
### Assignee Tasks

- [x] Removed an incomplete updating of the user's state where the cart property was updated to match that of the cart's store.
- [x] Getting it to update for every single action the cart takes is redundant, and will take more time than we have at this point, this property can be ignored after initial loading. The cart store is talking to the database about order updates, anyhow.

### Guidelines

Please add a description of this Pull Request's motivation, scope, outstanding issues or potential alternatives, reasoning behind the current solution, and any other relevant information for posterity.

---

*Your PR Notes Here*
